### PR TITLE
add removeDragEl() method to 'add' event

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -384,7 +384,9 @@
 						rootEl.dispatchEvent(_createEvent('remove', dragEl));
 
 						// Add event
-						dragEl.dispatchEvent(_createEvent('add', dragEl));
+						var addEvent = _createEvent('add', dragEl);
+						addEvent.removeDragEl = function () { dragEl.parentNode.removeChild(dragEl); };
+						dragEl.dispatchEvent(addEvent);
 					}
 					else if( dragEl.nextSibling !== nextEl ){
 						// Update event


### PR DESCRIPTION
In an Angular ng-repeat context, the drag element must be removed just prior to updating the list.
This patch provides a convenience function for easily handling this situation by calling removeDragEl() on the 'add' event.
