### PR TITLE
Extract JSHint settings into .jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,24 @@
+{
+	"strict": true,
+	"newcap": false,	// "Tolerate uncapitalized constructors"
+	"node": true,
+	"expr": true,	// - true && call() "Expected an assignment or function call and instead saw an expression."
+	"supernew": true,	// - "Missing '()' invoking a constructor."
+	"laxbreak": true,
+	"white": true,
+	"globals": {
+		"define": true,
+		"test": true,
+		"expect": true,
+		"module": true,
+		"asyncTest": true,
+		"start": true,
+		"ok": true,
+		"equal": true,
+		"notEqual": true,
+		"deepEqual": true,
+		"window": true,
+		"document": true,
+		"performance": true
+	}
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,28 +12,7 @@ module.exports = function (grunt) {
 			all: ['*.js', '!*.min.js'],
 
 			options: {
-				strict: true,
-				newcap: false,	// "Tolerate uncapitalized constructors"
-				node: true,
-				expr: true, // - true && call() "Expected an assignment or function call and instead saw an expression."
-				supernew: true, // - "Missing '()' invoking a constructor."
-				laxbreak: true,
-				white: true,
-				globals: {
-					define: true,
-					test: true,
-					expect: true,
-					module: true,
-					asyncTest: true,
-					start: true,
-					ok: true,
-					equal: true,
-					notEqual: true,
-					deepEqual: true,
-					window: true,
-					document: true,
-					performance: true
-				}
+				jshintrc: true
 			}
 		},
 


### PR DESCRIPTION
Editors/IDEs can now pass options to JSHint.

Fix #155
