### PR TITLE
Ignore <template> when setting index

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -900,7 +900,7 @@
 	 */
 	function _index(/**HTMLElement*/el) {
 		var index = 0;
-		while (el && (el = el.previousElementSibling)) {
+		while (el && (el = el.previousElementSibling) && (el.nodeName !== 'TEMPLATE')) {
 			index++;
 		}
 		return index;


### PR DESCRIPTION
Not sure if this would be handy but it has helped when using Sortable on template driven lists. Prevents something like this:

```
<ul>
  <template>
    <li>Index 1</li>
  <template>
</ul>
```
