### PR TITLE
Sort event does not always fire

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -601,7 +601,7 @@
 					_disableDraggable(dragEl);
 					_toggleClass(dragEl, this.options.ghostClass, false);
 
-					if (!rootEl.contains(dragEl)) {
+					if (rootEl !== dragEl.parentNode) {
 						// drag from one list and drop into another
 						_dispatchEvent(dragEl.parentNode, 'sort', dragEl, rootEl, startIndex, newIndex);
 						_dispatchEvent(rootEl, 'sort', dragEl, rootEl, startIndex, newIndex);


### PR DESCRIPTION
In the dev branch the `sort` event is not always correctly called on the receiving list. This IS working in the latest released branch. The fix is trivial and included in this PR.

The case is illustrated in this JsBin: http://jsbin.com/muxojulevo/3/edit. It occurs whenever an item is picked up from a list and dropped in a nested container.
