### PR TITLE
Fixed angular directive for complex ng-repeat expressions

### DIFF
--- a/ng-sortable.js
+++ b/ng-sortable.js
@@ -17,10 +17,9 @@ angular.module('ng-sortable', [])
 						(node.nodeValue.indexOf('ngRepeat:') !== -1)
 					);
 			})[0];
-			ngRepeat = ngRepeat.nodeValue.match(/ngRepeat:\s*([\s\S]+?)\s+in\s+([\s\S]+?)(?:\s)/);
+			ngRepeat = ngRepeat.nodeValue.match(/ngRepeat:\s*(?:\(.*?,\s*)?([^\s)]+)[\s)]+in\s+([^\s|]+)/);
 
-			var lhs = ngRepeat[1].match(/^(?:([\$\w]+)|\(([\$\w]+)\s*,\s*([\$\w]+)\))$/);
-			var itemExpr = $parse(lhs[3] || lhs[1]);
+			var itemExpr = $parse(ngRepeat[1]);
 			var itemsExpr = $parse(ngRepeat[2]);
 
 			return {


### PR DESCRIPTION
This fix will allow `ng-sortable` directive to work properly with complex `ng-repeat` expressions such as `(index, item) in some.list track by $index`
