### PR TITLE
Make Sortable compatible xhtml

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -809,7 +809,7 @@
 			do {
 				if (
 					(tag === '>*' && el.parentNode === ctx) || (
-						(tag === '' || el.nodeName == tag) &&
+						(tag === '' || el.nodeName.toUpperCase() == tag) &&
 						(!selector.length || ((' ' + el.className + ' ').match(re) || []).length == selector.length)
 					)
 				) {
@@ -937,7 +937,7 @@
 	 */
 	function _index(/**HTMLElement*/el) {
 		var index = 0;
-		while (el && (el = el.previousElementSibling) && (el.nodeName !== 'TEMPLATE')) {
+		while (el && (el = el.previousElementSibling) && (el.nodeName.toUpperCase() !== 'TEMPLATE')) {
 			index++;
 		}
 		return index;


### PR DESCRIPTION
comparisons of node names (via the nodeName property) are done in upper case. However, nodeName is lower case in xhtml. Let's do everything in upper case.
