### PR TITLE
Support Composer package manager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,16 @@
     "description": "Sortable is a JavaScript library for reorderable drag-and-drop lists.",
     "homepage": "http://rubaxa.github.io/Sortable/",
     "license": "MIT",
-    "authors": [{
-        "name": "RubaXa",
-        "email": "ibnRubaXa@gmail.com"
-    }],
+    "authors": [
+      {
+          "name": "Wayne Van Son",
+          "email": "waynevanson@gmail.com"
+      },
+      {
+          "name": "Owen Mills",
+          "email": "owen23355@gmail.com"
+      }
+    ],
     "keywords": [
         "sortable",
         "reorder",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     ],
     "support": {
         "issues": "https://github.com/RubaXa/Sortable/issues",
-        "source": "https://github.com/RubaXa/Sortable.git"
+        "source": "https://github.com/SortableJS/Sortable.git"
     },
     "prefer-stable": true,
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,7 @@
         "component": {
             "files": [
                 "Sortable.js",
-                "Sortable.min.js",
-                "jquery.binding.js"
+                "Sortable.min.js"
             ]
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "rubaxa/sortable",
+    "name": "SortableJS/Sortable",
     "type": "component",
     "description": "Sortable is a JavaScript library for reorderable drag-and-drop lists.",
     "homepage": "http://sortablejs.github.io/Sortable/",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "components/Sortable",
+    "name": "rubaxa/sortable",
     "type": "component",
     "description": "Sortable is a JavaScript library for reorderable drag-and-drop lists.",
     "homepage": "http://rubaxa.github.io/Sortable/",

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,36 @@
+{
+    "name": "components/Sortable",
+    "type": "component",
+    "description": "Sortable is a JavaScript library for reorderable drag-and-drop lists.",
+    "homepage": "http://rubaxa.github.io/Sortable/",
+    "license": "MIT",
+    "authors": [{
+        "name": "RubaXa",
+        "email": "ibnRubaXa@gmail.com"
+    }],
+    "keywords": [
+        "sortable",
+        "reorder",
+        "list",
+        "html5",
+        "drag",
+        "and",
+        "drop",
+        "dnd"
+    ],
+    "support": {
+        "issues": "https://github.com/RubaXa/Sortable/issues",
+        "source": "https://github.com/RubaXa/Sortable.git"
+    },
+    "prefer-stable": true,
+    "minimum-stability": "dev",
+    "extra": {
+        "component": {
+            "files": [
+                "Sortable.js",
+                "Sortable.min.js",
+                "jquery.binding.js"
+            ]
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "dnd"
     ],
     "support": {
-        "issues": "https://github.com/RubaXa/Sortable/issues",
+        "issues": "https://github.com/SortableJS/Sortable/issues",
         "source": "https://github.com/SortableJS/Sortable.git"
     },
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "rubaxa/sortable",
     "type": "component",
     "description": "Sortable is a JavaScript library for reorderable drag-and-drop lists.",
-    "homepage": "http://rubaxa.github.io/Sortable/",
+    "homepage": "http://sortablejs.github.io/Sortable/",
     "license": "MIT",
     "authors": [
       {


### PR DESCRIPTION
After merging this PR, the `RubaXa/Sortable` repo can be submitted to Packagist.org under the `RubaXa` org. Clean and simple no more maintaining of [forks](https://github.com/components/Sortable). Hooray!