### PR TITLE
Add option extendDropElement.

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -277,6 +277,7 @@
 			fallbackTolerance: 0,
 			fallbackOffset: {x: 0, y: 0},
 			supportPointer: Sortable.supportPointer !== false,
+			extendDropElement: null
 		};
 
 
@@ -305,6 +306,17 @@
 		if (this.nativeDraggable) {
 			_on(el, 'dragover', this);
 			_on(el, 'dragenter', this);
+		}
+
+		// set extendDropElement
+		if (options.extendDropElement) {
+			var extEl = options.extendDropElement
+			if (!(extEl.nodeType && extEl.nodeType === 1)) {
+				throw 'Sortable: `extendDropElement` must be HTMLElement, and not ' + {}.toString.call(extEl);
+			}
+			console.log(extEl);
+			_on(extEl, 'dragover', this);
+			_on(extEl, 'dragenter', this);
 		}
 
 		touchDragOverListeners.push(this._onDragOver);


### PR DESCRIPTION
I fount that if I use Sortablejs with `tbody` as `el` when `create`, I would not be able to drag&drop rows from one table to another when the `tbody` is empty.

Here is an example,

![without_extendDropElement](https://user-images.githubusercontent.com/732769/32316761-8190df96-bfec-11e7-8749-cb13b58607bb.gif)

So I added an option `extendDropElement`, which allows user to set an extend element where items can be dropped in. By setting `extendDropElement` to `thead`, I can drag&drop rows into an empty table tbody.

![with_extendDropElement](https://user-images.githubusercontent.com/732769/32316880-f67b749c-bfec-11e7-89b7-e5e055eb1332.gif)
