### PR TITLE
Updated Sortable.js to catch empty "order" array

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -1117,12 +1117,14 @@
 				}
 			}, this);
 
-			order.forEach(function (id) {
-				if (items[id]) {
-					rootEl.removeChild(items[id]);
-					rootEl.appendChild(items[id]);
-				}
-			});
+			if (typeof order !== 'undefined') {
+				order.forEach(function (id) {
+					if (items[id]) {
+						rootEl.removeChild(items[id]);
+						rootEl.appendChild(items[id]);
+					}
+				});
+			}
 		},
 
 


### PR DESCRIPTION
If I don't set up the Store Get function (because I'm only using Set) fully, I get the error "TypeError: order is undefined" at line 1057 of Sortable.js.  (I don't want to change the order of the original list so I don't have a return statement, or return null.)  This fixes that error message.