### PR TITLE
Fix Issue where an overflowing parent is scrolled but it has overflow: hidden

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -107,8 +107,8 @@
 			var gotSelf = false;
 			do {
 				if (
-					(elem.clientWidth < elem.scrollWidth && ['auto', 'scroll'].includes(elem.style.overflowX)) ||
-          (elem.clientHeight < elem.scrollHeight && ['auto', 'scroll'].includes(elem.style.overflowY))
+					(elem.clientWidth < elem.scrollWidth && (elem.style.overflowX == 'auto' || elem.style.overflowX == 'scroll')) ||
+          (elem.clientHeight < elem.scrollHeight && (elem.style.overflowY == 'auto' || elem.style.overflowY == 'scroll'))
 				) {
 					if (!elem || !elem.getBoundingClientRect || elem === document.body) return;
 

--- a/Sortable.js
+++ b/Sortable.js
@@ -107,8 +107,8 @@
 			var gotSelf = false;
 			do {
 				if (
-					(elem.clientWidth < elem.scrollWidth) ||
-					(elem.clientHeight < elem.scrollHeight)
+					(elem.clientWidth < elem.scrollWidth && ['auto', 'scroll'].includes(elem.style.overflowX)) ||
+          (elem.clientHeight < elem.scrollHeight && ['auto', 'scroll'].includes(elem.style.overflowY))
 				) {
 					if (!elem || !elem.getBoundingClientRect || elem === document.body) return;
 


### PR DESCRIPTION
Currently the auto scroll code does not check if the overflowing parent is a scrolling container. This fix addresses the issue.