### PR TITLE
Remove 'fixing dimensions' because it breaks dimensions

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -724,8 +724,7 @@
 			if (!ghostEl) {
 				var rect = dragEl.getBoundingClientRect(),
 					css = _css(dragEl),
-					options = this.options,
-					ghostRect;
+					options = this.options;
 
 				ghostEl = dragEl.cloneNode(true);
 
@@ -743,11 +742,6 @@
 				_css(ghostEl, 'pointerEvents', 'none');
 
 				options.fallbackOnBody && document.body.appendChild(ghostEl) || rootEl.appendChild(ghostEl);
-
-				// Fixing dimensions.
-				ghostRect = ghostEl.getBoundingClientRect();
-				_css(ghostEl, 'width', rect.width * 2 - ghostRect.width);
-				_css(ghostEl, 'height', rect.height * 2 - ghostRect.height);
 			}
 		},
 


### PR DESCRIPTION
In my implementation this code snippet breaks my dimensions instead of fixing them. Without it, it works like a charm. Why is this snippiet needed and how does the calculation work?