### PR TITLE
Fix drag on android 4.4 or lower

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -1816,6 +1816,8 @@
 					return el.matches(selector);
 				} else if (el.msMatchesSelector) {
 					return el.msMatchesSelector(selector);
+				} else if (el.webkitMatchesSelector) {
+					return el.webkitMatchesSelector(selector);
 				}
 			} catch(_) {
 				return false;


### PR DESCRIPTION
Drag & filter doesn't work on webview provided by  android 4.4 or lower, since el.matches is not yet implemented, webkitMatchesSelector should work well.

Ignore the last line-break, it's added by web editor on github.