### PR TITLE
Add option to only apply delay on touch events

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ var sortable = new Sortable(el, {
 	group: "name",  // or { name: "...", pull: [true, false, 'clone', array], put: [true, false, array] }
 	sort: true,  // sorting inside list
 	delay: 0, // time in milliseconds to define when the sorting should start
+	delayOnTouchOnly: false, // only delay if user is using touch
 	touchStartThreshold: 0, // px, how many pixels the point should move before cancelling a delayed drag event
 	disabled: false, // Disables the sortable if set to true.
 	store: null,  // @see Store
@@ -240,6 +241,13 @@ Time in milliseconds to define when the sorting should start.
 Unfortunately, due to browser restrictions, delaying is not possible on IE or Edge with native drag & drop.
 
 Demo: https://jsbin.com/zosiwah/edit?js,output
+
+
+---
+
+
+#### `delayOnTouchOnly` option
+Whether or not the delay should be applied only if the user is using touch (eg. on a mobile device). No delay will be applied in any other case. Defaults to `false`.
 
 
 ---

--- a/Sortable.js
+++ b/Sortable.js
@@ -533,6 +533,7 @@
 			dragoverBubble: false,
 			dataIdAttr: 'data-id',
 			delay: 0,
+			delayOnTouch: false,
 			touchStartThreshold: parseInt(window.devicePixelRatio, 10) || 1,
 			forceFallback: false,
 			fallbackClass: 'sortable-fallback',
@@ -820,7 +821,7 @@
 				}
 
 				// Delay is impossible for native DnD in Edge or IE
-				if (options.delay && (!this.nativeDraggable || !(Edge || IE11OrLess))) {
+				if (options.delay && (options.delayOnTouch && touch !== undefined) && (!this.nativeDraggable || !(Edge || IE11OrLess))) {
 					// If the user moves the pointer or let go the click or touch
 					// before the delay has been reached:
 					// disable the delayed drag

--- a/Sortable.js
+++ b/Sortable.js
@@ -533,7 +533,7 @@
 			dragoverBubble: false,
 			dataIdAttr: 'data-id',
 			delay: 0,
-			delayOnTouch: false,
+			delayOnTouchOnly: false,
 			touchStartThreshold: parseInt(window.devicePixelRatio, 10) || 1,
 			forceFallback: false,
 			fallbackClass: 'sortable-fallback',
@@ -821,7 +821,7 @@
 				}
 
 				// Delay is impossible for native DnD in Edge or IE
-				if (options.delay && (options.delayOnTouch && touch !== undefined) && (!this.nativeDraggable || !(Edge || IE11OrLess))) {
+				if (options.delay && (options.delayOnTouchOnly ? touch : true) && (!this.nativeDraggable || !(Edge || IE11OrLess))) {
 					// If the user moves the pointer or let go the click or touch
 					// before the delay has been reached:
 					// disable the delayed drag


### PR DESCRIPTION
We're creating a sort of Kanban in our project where the requirements dont allow for drag handles. 

Added a new config option that allows you to apply a delay only if the event was a touchevent 