### PR TITLE
Update Sortable.js

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -85,7 +85,7 @@
 
 		win = window,
 		document = win.document,
-		parseInt = win.parseInt,
+		parseInt = win.parseInt || global.parseInt,
 		setTimeout = win.setTimeout,
 
 		$ = win.jQuery || win.Zepto,


### PR DESCRIPTION
handle the window.parseInt not exists in env 'Vue Test Utils'.