### PR TITLE
fix: fallbackTolerance cause can not drag horizontally or vertically

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -989,7 +989,7 @@
 				// only set the status to dragging, when we are actually dragging
 				if (!Sortable.active && !awaitingDragStarted) {
 					if (fallbackTolerance &&
-						min(abs(touch.clientX - this._lastX), abs(touch.clientY - this._lastY)) < fallbackTolerance
+						max(abs(touch.clientX - this._lastX), abs(touch.clientY - this._lastY)) < fallbackTolerance
 					) {
 						return;
 					}


### PR DESCRIPTION
Check out line 990-997:
https://github.com/SortableJS/Sortable/blob/2f00519da6918876433df81c548d87682477022c/Sortable.js#L990-L997

When `fallbackTolerance` is set and dragging horizontally or vertically,  `minimum value` always be 0,  so it cannot trigger `_onDragStart` but directly return.

So I think the reasonable value which compare with fallbackTolerance should be `Euclidean distance` of ` (touch.clientX, touch.clientY) ` and  `(this._lastX, this._lastY)`,   which is :

```
Math.sqrt(Math.pow(abs(touch.clientX - this._lastX), 2) + Math.pow(abs(touch.clientY - this._lastY) ,2))  < fallbackTolerance
```

**Considering performance,**  `Maximum value` can work properly in this situation.

So I change it to

```
 max(abs(touch.clientX - this._lastX), abs(touch.clientY - this._lastY)) < fallbackTolerance
```