### PR TITLE
rename angularjs to angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Supported by [<img width="100px" src="https://user-images.githubusercontent.com/
  * Built using native HTML5 drag and drop API
  * Supports
    * [Meteor](https://github.com/SortableJS/meteor-sortablejs)
-   * AngularJS
+   * Angular
      * [2.0+](https://github.com/SortableJS/angular-sortablejs)
      * [1.*](https://github.com/SortableJS/angular-legacy-sortablejs)
    * React


### PR DESCRIPTION
from 2.0+ Angular is not .js anymore, it is more correct to call it just Angular