### PR TITLE
only loop through own properties inside for..in

### DIFF
--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -224,15 +224,17 @@ let dragEl,
 	 */
 	_detectNearestEmptySortable = function(x, y) {
 		for (let i in sortables) {
-			if (lastChild(sortables[i])) continue;
+			if (sortables.hasOwnProperty(i)) {
+				if (lastChild(sortables[i])) continue;
 
-			let rect = getRect(sortables[i]),
-				threshold = sortables[i][expando].options.emptyInsertThreshold,
-				insideHorizontally = x >= (rect.left - threshold) && x <= (rect.right + threshold),
-				insideVertically = y >= (rect.top - threshold) && y <= (rect.bottom + threshold);
+				let rect = getRect(sortables[i]),
+					threshold = sortables[i][expando].options.emptyInsertThreshold,
+					insideHorizontally = x >= (rect.left - threshold) && x <= (rect.right + threshold),
+					insideVertically = y >= (rect.top - threshold) && y <= (rect.bottom + threshold);
 
-			if (threshold && insideHorizontally && insideVertically) {
-				return sortables[i];
+				if (threshold && insideHorizontally && insideVertically) {
+					return sortables[i];
+				}
 			}
 		}
 	},
@@ -312,7 +314,8 @@ let nearestEmptyInsertDetectEvent = function(evt) {
 			// Create imitation event
 			let event = {};
 			for (let i in evt) {
-				event[i] = evt[i];
+				if (evt.hasOwnProperty(i))
+					event[i] = evt[i];
 			}
 			event.target = event.rootEl = nearest;
 			event.preventDefault = void 0;
@@ -1884,13 +1887,15 @@ Sortable.mount = function(...plugins) {
 	if (plugins[0].constructor === Array) plugins = plugins[0];
 
 	for (let i in plugins) {
-		let plugin = plugins[i];
-		if (!plugin.prototype || !plugin.prototype.constructor) {
-			throw `Sortable: Mounted plugin must be a constructor function, not ${ {}.toString.call(el) }`;
-		}
-		if (plugin.utils) Sortable.utils = { ...Sortable.utils, ...plugin.utils };
+		if (plugins.hasOwnProperty(i)) {
+			let plugin = plugins[i];
+			if (!plugin.prototype || !plugin.prototype.constructor) {
+				throw `Sortable: Mounted plugin must be a constructor function, not ${ {}.toString.call(el) }`;
+			}
+			if (plugin.utils) Sortable.utils = { ...Sortable.utils, ...plugin.utils };
 
-		PluginManager.mount(plugin);
+			PluginManager.mount(plugin);
+		}
 	}
 };
 


### PR DESCRIPTION
Right now, the `for..in` loops are running through all properties. I think it would be wise to check for the own properties, because other libraries could mess with the native types, like the one I'm facing right now.