### PR TITLE
#1547: add initial in-repo typescript support

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 	"files": [
 		"Sortable.js",
 		"Sortable.min.js",
+		"types/",
 		"modular/"
 	],
 	"keywords": [
@@ -47,5 +48,6 @@
 		"vue",
 		"mixin"
 	],
+	"types": "./types/index.d.ts",
 	"license": "MIT"
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,10 @@
+import { Sortable } from './sortable';
+
+export default Sortable;
+
+export * from './sortable';
+export * from './sortable-event';
+export * from './sortable-options';
+export * from './sortable-plugins';
+export * from './sortable-utils';
+

--- a/types/sortable-event.d.ts
+++ b/types/sortable-event.d.ts
@@ -9,13 +9,25 @@ export interface SortableEvent extends Event {
 	 */
 	item: HTMLElement;
 	/**
+	 * new index within parent, only counting draggable elements
+	 */
+	newDraggableIndex: number | undefined;
+	/**
 	 * new index within parent
 	 */
 	newIndex: number | undefined;
 	/**
+	 * old index within parent, only counting draggable elements
+	 */
+	oldDraggableIndex: number | undefined;
+	/**
 	 * old index within parent
 	 */
 	oldIndex: number | undefined;
+	/**
+	 * Pull mode if dragging into another sortable
+	 */
+	pullMode: 'clone' | boolean | undefined;
 	target: HTMLElement;
 	/**
 	 * list, in which moved element.

--- a/types/sortable-event.d.ts
+++ b/types/sortable-event.d.ts
@@ -1,0 +1,48 @@
+export interface SortableEvent extends Event {
+	clone: HTMLElement;
+	/**
+	 * previous list
+	 */
+	from: HTMLElement;
+	/**
+	 * dragged element
+	 */
+	item: HTMLElement;
+	/**
+	 * new index within parent
+	 */
+	newIndex: number | undefined;
+	/**
+	 * old index within parent
+	 */
+	oldIndex: number | undefined;
+	target: HTMLElement;
+	/**
+	 * list, in which moved element.
+	 */
+	to: HTMLElement;
+}
+
+export interface SortableMoveEvent extends Event {
+	dragged: HTMLElement;
+	draggedRect: SortableDOMRect;
+	from: HTMLElement;
+	/**
+	 * element on which have guided
+	 */
+	related: HTMLElement;
+	relatedRect: SortableDOMRect;
+	to: HTMLElement;
+	willInsertAfter?: boolean;
+}
+
+export interface SortableDOMRect {
+	bottom: number;
+	height: number;
+	left: number;
+	right: number;
+	top: number;
+	width: number;
+	x: number;
+	y: number;
+}

--- a/types/sortable-options.d.ts
+++ b/types/sortable-options.d.ts
@@ -23,7 +23,7 @@ export interface SortableGroupOptions {
 	 */
 	checkPut?: (to: Sortable) => boolean;
 	/**
-	 * revert cloned element to initial position after moving to a another list.
+	 * revert cloned element to initial position after moving to another list.
 	 */
 	revertClone?: boolean;
 }
@@ -42,6 +42,14 @@ export interface SortableOptions {
 	 * time in milliseconds to define when the sorting should start
 	 */
 	delay?: number;
+	/*
+	 * only delay if user is using touch
+	 */
+	delayOnTouchOnly?: Boolean;
+	/**
+	 * Direction of Sortable (will be detected automatically if not given)
+	 */
+	direction?: 'horizontal' | 'vertical' | ((event: Event, target: HTMLElement, dragEl: HTMLElement) => 'horizontal'|'vertical');
 	/**
 	 * Disables the sortable if set to true.
 	 */
@@ -56,6 +64,14 @@ export interface SortableOptions {
 	draggable?: string;
 	dragoverBubble?: boolean;
 	dropBubble?: boolean;
+	/**
+	 * Easing for animation. Defaults to null. See https://easings.net/ for examples.
+	 */
+	easing?: string;
+	/**
+	 * distance in px mouse must be from empty sortable to insert drag element into it
+	 */
+	emptyInsertThreshold?: number;
 	/**
 	 * Class name for the cloned DOM Element when using forceFallback
 	 */
@@ -92,9 +108,21 @@ export interface SortableOptions {
 	handle?: string;
 	ignore?: string;
 	/**
+	 * Threshold of the inverted swap zone (will be set to swapThreshold value by default)
+	 */
+	invertedSwapThreshold?: number,
+	/**
+	 * Will always use inverted swap zone if set to true
+	 */
+	invertSwap?: boolean,
+	/**
 	 * Call `event.preventDefault()` when triggered `filter`
 	 */
 	preventOnFilter?: boolean;
+	/**
+	 * Remove the clone element when it is not showing, rather than just hiding it
+	 */
+	removeCloneOnHide?: boolean;
 	scroll?: boolean;
 	/**
 	 * if you have custom scrollbar scrollFn may be used for autoscrolling
@@ -116,6 +144,14 @@ export interface SortableOptions {
 		get: (sortable: Sortable) => string[];
 		set: (sortable: Sortable) => void;
 	};
+	/*
+	 * Threshold of the swap zone
+	 */
+	swapThreshold?: number,
+	/*
+	 * how many pixels the point should move before cancelling a delayed drag event
+	 */
+	touchStartThreshold?: number;
 	setData?: (dataTransfer: DataTransfer, draggedElement: HTMLElement) => void;
 	/**
 	 * Element dragging started
@@ -133,6 +169,10 @@ export interface SortableOptions {
 	 * Created a clone of an element
 	 */
 	onClone?: (event: SortableEvent) => void;
+	/**
+	 * Dragging element changes position
+	 */
+	onChange?: (event: SortableEvent) => void;
 	/**
 	 * Element is chosen
 	 */

--- a/types/sortable-options.d.ts
+++ b/types/sortable-options.d.ts
@@ -1,0 +1,164 @@
+import { Sortable } from './sortable';
+import { SortableEvent, SortableMoveEvent } from './sortable-event';
+
+export interface SortableGroupOptions {
+	/**
+	 * group name
+	 */
+	name: string;
+	/**
+	 * ability to move from the list. clone — copy the item, rather than move.
+	 */
+	pull?: boolean | 'clone' | ((to: Sortable, from: Sortable) => boolean | string);
+	/**
+	 * whether elements can be added from other lists, or an array of group names from which elements can be taken.
+	 */
+	put?: boolean | string | ReadonlyArray<string> | ((to: Sortable) => boolean);
+	/**
+	 * a canonical version of pull, created by Sortable
+	 */
+	checkPull?: ((to: Sortable, from: Sortable) => boolean | string);
+	/**
+	 * a canonical version of put, created by Sortable
+	 */
+	checkPut?: (to: Sortable) => boolean;
+	/**
+	 * revert cloned element to initial position after moving to a another list.
+	 */
+	revertClone?: boolean;
+}
+
+export interface SortableOptions {
+	/**
+	 * ms, animation speed moving items when sorting, `0` — without animation
+	 */
+	animation?: number;
+	/**
+	 * Class name for the chosen item
+	 */
+	chosenClass?: string;
+	dataIdAttr?: string;
+	/**
+	 * time in milliseconds to define when the sorting should start
+	 */
+	delay?: number;
+	/**
+	 * Disables the sortable if set to true.
+	 */
+	disabled?: boolean;
+	/**
+	 * Class name for the dragging item
+	 */
+	dragClass?: string;
+	/**
+	 * Specifies which items inside the element should be draggable
+	 */
+	draggable?: string;
+	dragoverBubble?: boolean;
+	dropBubble?: boolean;
+	/**
+	 * Class name for the cloned DOM Element when using forceFallback
+	 */
+	fallbackClass?: string;
+	/**
+	 * Appends the cloned DOM Element into the Document's Body
+	 */
+	fallbackOnBody?: boolean;
+	/**
+	 * Specify in pixels how far the mouse should move before it's considered as a drag.
+	 */
+	fallbackTolerance?: number;
+	fallbackOffset?: { x: number, y: number };
+	/**
+	 * Selectors that do not lead to dragging (String or Function)
+	 */
+	filter?: string | ((this: Sortable, event: Event | TouchEvent, target: HTMLElement, sortable: Sortable) => boolean);
+	/**
+	 * ignore the HTML5 DnD behaviour and force the fallback to kick in
+	 */
+	forceFallback?: boolean;
+	/**
+	 * Class name for the drop placeholder
+	 */
+	ghostClass?: string;
+	/**
+	 * To drag elements from one list into another, both lists must have the same group value.
+	 * You can also define whether lists can give away, give and keep a copy (clone), and receive elements.
+	 */
+	group?: string | SortableGroupOptions;
+	/**
+	 * Drag handle selector within list items
+	 */
+	handle?: string;
+	ignore?: string;
+	/**
+	 * Call `event.preventDefault()` when triggered `filter`
+	 */
+	preventOnFilter?: boolean;
+	scroll?: boolean;
+	/**
+	 * if you have custom scrollbar scrollFn may be used for autoscrolling
+	 */
+	scrollFn?: ((this: Sortable, offsetX: number, offsetY: number, event: MouseEvent) => void);
+	/**
+	 * px, how near the mouse must be to an edge to start scrolling.
+	 */
+	scrollSensitivity?: number;
+	/**
+	 * px
+	 */
+	scrollSpeed?: number;
+	/**
+	 * sorting inside list
+	 */
+	sort?: boolean;
+	store?: {
+		get: (sortable: Sortable) => string[];
+		set: (sortable: Sortable) => void;
+	};
+	setData?: (dataTransfer: DataTransfer, draggedElement: HTMLElement) => void;
+	/**
+	 * Element dragging started
+	 */
+	onStart?: (event: SortableEvent) => void;
+	/**
+	 * Element dragging ended
+	 */
+	onEnd?: (event: SortableEvent) => void;
+	/**
+	 * Element is dropped into the list from another list
+	 */
+	onAdd?: (event: SortableEvent) => void;
+	/**
+	 * Created a clone of an element
+	 */
+	onClone?: (event: SortableEvent) => void;
+	/**
+	 * Element is chosen
+	 */
+	onChoose?: (event: SortableEvent) => void;
+	/**
+	 * Element is unchosen
+	 */
+	onUnchoose?: (event: SortableEvent) => void;
+	/**
+	 * Changed sorting within list
+	 */
+	onUpdate?: (event: SortableEvent) => void;
+	/**
+	 * Called by any change to the list (add / update / remove)
+	 */
+	onSort?: (event: SortableEvent) => void;
+	/**
+	 * Element is removed from the list into another list
+	 */
+	onRemove?: (event: SortableEvent) => void;
+	/**
+	 * Attempt to drag a filtered element
+	 */
+	onFilter?: (event: SortableEvent) => void;
+	/**
+	 * Event when you move an item in the list or between lists
+	 */
+	onMove?: (event: SortableMoveEvent) => boolean;
+}

--- a/types/sortable-plugins.d.ts
+++ b/types/sortable-plugins.d.ts
@@ -1,0 +1,7 @@
+export interface SortablePlugin { }
+
+export class AutoScroll implements SortablePlugin { }
+export class RevertOnSpill implements SortablePlugin { }
+export class RemoveOnSpill implements SortablePlugin { }
+export class MultiDrag implements SortablePlugin { }
+export class Swap implements SortablePlugin { }

--- a/types/sortable-utils.d.ts
+++ b/types/sortable-utils.d.ts
@@ -1,0 +1,69 @@
+export interface SortableUtils {
+	/**
+	 * Attach an event handler function
+	 * @param element an HTMLElement.
+	 * @param event an Event context.
+	 * @param fn
+	 */
+	on(element: HTMLElement, event: string, fn: EventListenerOrEventListenerObject): void;
+
+	/**
+	 * Remove an event handler function
+	 * @param element an HTMLElement.
+	 * @param event an Event context.
+	 * @param fn a callback.
+	 */
+	off(element: HTMLElement, event: string, fn: EventListenerOrEventListenerObject): void;
+
+	/**
+	 * Get the values of all the CSS properties.
+	 * @param element an HTMLElement.
+	 */
+	css(element: HTMLElement): CSSStyleDeclaration;
+
+	/**
+	 * Get the value of style properties.
+	 * @param element an HTMLElement.
+	 * @param prop a property key.
+	 */
+	css<K extends keyof CSSStyleDeclaration>(element: HTMLElement, prop: K): CSSStyleDeclaration[K];
+
+	/**
+	 * Set one CSS property.
+	 * @param element an HTMLElement.
+	 * @param prop a property key.
+	 * @param value a property value.
+	 */
+	css<K extends keyof CSSStyleDeclaration>(element: HTMLElement, prop: K, value: CSSStyleDeclaration[K]): void;
+
+	/**
+	 * Get elements by tag name.
+	 * @param context an HTMLElement.
+	 * @param tagName A tag name.
+	 * @param iterator An iterator.
+	 */
+	find(context: HTMLElement, tagName: string, iterator?: (value: HTMLElement, index: number) => void): NodeListOf<HTMLElement>;
+
+	/**
+	 * Check the current matched set of elements against a selector.
+	 * @param element an HTMLElement.
+	 * @param selector an element selector.
+	 */
+	is(element: HTMLElement, selector: string): boolean;
+
+	/**
+	 * For each element in the set, get the first element that matches the selector by testing the element itself and traversing up through its ancestors in the DOM tree.
+	 * @param element an HTMLElement.
+	 * @param selector an element seletor.
+	 * @param context a specific element's context.
+	 */
+	closest(element: HTMLElement, selector: string, context?: HTMLElement): HTMLElement | null;
+
+	/**
+	 * Add or remove one classes from each element
+	 * @param element an HTMLElement.
+	 * @param name a class name.
+	 * @param state a class's state.
+	 */
+	toggleClass(element: HTMLElement, name: string, state: boolean): void;
+}

--- a/types/sortable-utils.d.ts
+++ b/types/sortable-utils.d.ts
@@ -66,4 +66,9 @@ export interface SortableUtils {
 	 * @param state a class's state.
 	 */
 	toggleClass(element: HTMLElement, name: string, state: boolean): void;
+	/**
+	 * Automatically detect the direction of the element as either 'vertical' or 'horizontal'
+	 * @param element an HTMLElement.
+	 */
+	detectDirection(element: HTMLElement): 'vertical' | 'horizontal';
 }

--- a/types/sortable.d.ts
+++ b/types/sortable.d.ts
@@ -3,60 +3,60 @@ import { SortablePlugin } from './sortable-plugins';
 import { SortableUtils } from './sortable-utils';
 
 export class Sortable {
-     options: SortableOptions;
-     el: HTMLElement;
+	options: SortableOptions;
+	el: HTMLElement;
 
-     static active: Sortable;
-     static utils: SortableUtils;
+	static active: Sortable;
+	static utils: SortableUtils;
 
-     constructor(element: HTMLElement, options: SortableOptions);
-
-     /**
-      * Creation of new instances.
-      * @param element Any variety of HTMLElement.
-      * @param options Sortable options object.
-      */
-     static create(element: HTMLElement, options: SortableOptions): Sortable;
+	constructor(element: HTMLElement, options: SortableOptions);
 
 	/**
-     * Mount a plugin.
-     * @param plugin A Sortable plugin.
-     */
-     static mount(plugins: SortablePlugin | SortablePlugin[]): void;
+	* Creation of new instances.
+	* @param element Any variety of HTMLElement.
+	* @param options Sortable options object.
+	*/
+	static create(element: HTMLElement, options: SortableOptions): Sortable;
 
-     /**
-      * Options getter/setter
-      * @param name a SortableOptions property.
-      * @param value a value.
-      */
-     option<K extends keyof SortableOptions>(name: K, value: SortableOptions[K]): void;
-     option<K extends keyof SortableOptions>(name: K): SortableOptions[K];
+	/**
+	* Mount a plugin.
+	* @param plugin A Sortable plugin.
+	*/
+	static mount(plugins: SortablePlugin | SortablePlugin[]): void;
 
-     /**
-      * For each element in the set, get the first element that matches the selector by testing the element itself and traversing up through its ancestors in the DOM tree.
-      * @param element an HTMLElement or selector string.
-      * @param selector default: `options.draggable`
-      */
-     closest(element: HTMLElement, selector?: string): HTMLElement | null;
+	/**
+	* Options getter/setter
+	* @param name a SortableOptions property.
+	* @param value a value.
+	*/
+	option<K extends keyof SortableOptions>(name: K, value: SortableOptions[K]): void;
+	option<K extends keyof SortableOptions>(name: K): SortableOptions[K];
 
-     /**
-      * Sorts the elements according to the array.
-      * @param order an array of strings to sort.
-      */
-     sort(order: ReadonlyArray<string>): void;
+	/**
+	* For each element in the set, get the first element that matches the selector by testing the element itself and traversing up through its ancestors in the DOM tree.
+	* @param element an HTMLElement or selector string.
+	* @param selector default: `options.draggable`
+	*/
+	closest(element: HTMLElement, selector?: string): HTMLElement | null;
 
-     /**
-      * Saving and restoring of the sort.
-      */
-     save(): void;
+	/**
+	* Sorts the elements according to the array.
+	* @param order an array of strings to sort.
+	*/
+	sort(order: ReadonlyArray<string>): void;
 
-     /**
-      * Removes the sortable functionality completely.
-      */
-     destroy(): void;
+	/**
+	* Saving and restoring of the sort.
+	*/
+	save(): void;
 
-     /**
-      * Serializes the sortable's item data-id's (dataIdAttr option) into an array of string.
-      */
-     toArray(): string[];
+	/**
+	* Removes the sortable functionality completely.
+	*/
+	destroy(): void;
+
+	/**
+	* Serializes the sortable's item data-id's (dataIdAttr option) into an array of string.
+	*/
+	toArray(): string[];
 }

--- a/types/sortable.d.ts
+++ b/types/sortable.d.ts
@@ -1,0 +1,62 @@
+import { SortableOptions } from './sortable-options';
+import { SortablePlugin } from './sortable-plugins';
+import { SortableUtils } from './sortable-utils';
+
+export class Sortable {
+     options: SortableOptions;
+     el: HTMLElement;
+
+     static active: Sortable;
+     static utils: SortableUtils;
+
+     constructor(element: HTMLElement, options: SortableOptions);
+
+     /**
+      * Creation of new instances.
+      * @param element Any variety of HTMLElement.
+      * @param options Sortable options object.
+      */
+     static create(element: HTMLElement, options: SortableOptions): Sortable;
+
+	/**
+     * Mount a plugin.
+     * @param plugin A Sortable plugin.
+     */
+     static mount(plugins: SortablePlugin | SortablePlugin[]): void;
+
+     /**
+      * Options getter/setter
+      * @param name a SortableOptions property.
+      * @param value a value.
+      */
+     option<K extends keyof SortableOptions>(name: K, value: SortableOptions[K]): void;
+     option<K extends keyof SortableOptions>(name: K): SortableOptions[K];
+
+     /**
+      * For each element in the set, get the first element that matches the selector by testing the element itself and traversing up through its ancestors in the DOM tree.
+      * @param element an HTMLElement or selector string.
+      * @param selector default: `options.draggable`
+      */
+     closest(element: HTMLElement, selector?: string): HTMLElement | null;
+
+     /**
+      * Sorts the elements according to the array.
+      * @param order an array of strings to sort.
+      */
+     sort(order: ReadonlyArray<string>): void;
+
+     /**
+      * Saving and restoring of the sort.
+      */
+     save(): void;
+
+     /**
+      * Removes the sortable functionality completely.
+      */
+     destroy(): void;
+
+     /**
+      * Serializes the sortable's item data-id's (dataIdAttr option) into an array of string.
+      */
+     toArray(): string[];
+}


### PR DESCRIPTION
Hi @owen-m1 

as discussed, here are the initial types files.

While creating them I had lots of questions, including e.g.

1. What is the type of plugin? Is this considered to be a class? Are there public methods / properties on plugins? Is it necessary to mention them in the definition files, in other words, is it possible / would it be useful to create a custom plugin?
2. Why are the plugin options and utils are embedded into sortable's options? Is this intentional? Why can't one pass the plugin options into the plugin itself while calling it with `new`?
3. `checkPull` and `checkPut` are not a part of documentation, however those functions are quite useful. I added them to options interface, however wouldn't they be good as part of utils?

And, generally, please check all types and missing functions / properties. I'm not that familiar with plugins and new functionality yet...

If you are not yet familiar with typescript, the interface is just a type that does not exist in the runtime, while class, const, let etc are existing in runtime. So, don't worry for exported interfaces (that they do not really exist), they are used as a type only