### PR TITLE
Fix/plugin register guard

### DIFF
--- a/src/PluginManager.js
+++ b/src/PluginManager.js
@@ -12,7 +12,9 @@ export default {
 				plugin[option] = defaults[option];
 			}
 		}
-		plugins.push(plugin);
+		if(!!~plugins.indexOf(plugin)) {
+			plugins.push(plugin);
+		}
 	},
 	pluginEvent(eventName, sortable, evt) {
 		this.eventCanceled = false;

--- a/src/PluginManager.js
+++ b/src/PluginManager.js
@@ -12,7 +12,7 @@ export default {
 				plugin[option] = defaults[option];
 			}
 		}
-		if(!!~plugins.indexOf(plugin)) {
+		if(!plugins.map(p => p.name).includes(plugin.name)) {
 			plugins.push(plugin);
 		}
 	},


### PR DESCRIPTION
Mounting the same plugin twice, results in doubling the number of registered Event listeners - causing unintended behaviour.

Discovered this while trying to implement [MultiDrag](https://github.com/SortableJS/Sortable/wiki/Dragging-Multiple-Items-in-Sortable) into [Vue.Draggable ](https://github.com/SortableJS/Vue.Draggable)

`toggleClass()` was called multiple times in case of _multiple/nested_ instances of Draggable component 