### PR TITLE
disable delayed drag events during destory

### DIFF
--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -1652,6 +1652,8 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 
 		this._onDrop();
 
+		this._disableDelayedDragEvents();
+
 		sortables.splice(sortables.indexOf(this.el), 1);
 
 		this.el = el = null;


### PR DESCRIPTION
I find if the `destory` method called before `_dragStartTimer` trigger, the events linsted by `ownerDocument` will not disabled.

https://jsbin.com/sezupey/edit?html,css,js,output

Could we use this pr fix?