### PR TITLE
Fix(utils): Chrome < 44 not support scrollingElement

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -147,10 +147,12 @@ function find(ctx, tagName, iterator) {
 
 
 function getWindowScrollingElement() {
-	if (IE11OrLess) {
-		return document.documentElement;
+	let scrollingElement = document.scrollingElement;
+
+	if (scrollingElement) {
+		return scrollingElement
 	} else {
-		return document.scrollingElement;
+		return document.documentElement
 	}
 }
 


### PR DESCRIPTION
When I use Chrome 41, got a lot of error of 'TypeError: Cannot read property getBoundingClientRect of undefined'.Because in 'utils.js' 'getWindowScrollingElement' function, Chrome < 44 FF < 47 not support scrollingElement too.