### PR TITLE
Remove transforms after drop to prevent overlap of adjacent children

### DIFF
--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -1351,6 +1351,7 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 			css(document.body, 'user-select', '');
 		}
 
+    css(dragEl, 'transform', '');
 
 		if (evt) {
 			if (moved) {

--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -1351,7 +1351,7 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 			css(document.body, 'user-select', '');
 		}
 
-    css(dragEl, 'transform', '');
+		css(dragEl, 'transform', '');
 
 		if (evt) {
 			if (moved) {


### PR DESCRIPTION
As mentioned in #1644 (and demoed here: https://jsfiddle.net/4kcbzLse/) there is a `transform: translateZ(0)` added when an item is first dragged, but this is not then removed when an item is dropped. This can cause any extruding child elements (such as tooltips) to be overlapped by adjacent content.

When an item is dropped, the now vestigial `transform: translateZ(0)` is removed, rather than simply left.