### PR TITLE
Added type check for 'dragStarted' variable as this is causing thousa…

### DIFF
--- a/plugins/MultiDrag/MultiDrag.js
+++ b/plugins/MultiDrag/MultiDrag.js
@@ -467,7 +467,7 @@ function MultiDragPlugin() {
 		},
 
 		_deselectMultiDrag(evt) {
-			if (dragStarted) return;
+			if (typeof dragStarted !== "undefined" && dragStarted) return;
 
 			// Only deselect if selection is in this sortable
 			if (multiDragSortable !== this.sortable) return;


### PR DESCRIPTION
Added type check for 'dragStarted' variable as this is causing thousands of console errors in Chrome, Firefox, Edge, IE, Safari before the first drag.
This change is harmless because it is just checking if the variable **dragStarted** is declared before using it.

Tested across all of the above browsers and working fine after this change.