### PR TITLE
Sortable fix for onDrop function

### DIFF
--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -1519,7 +1519,9 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 		switch (evt.type) {
 			case 'drop':
 			case 'dragend':
-				this._onDrop(evt);
+				if (this._onDrop) {
+					this._onDrop(evt);
+				}
 				break;
 
 			case 'dragenter':


### PR DESCRIPTION
While drag end we are getting an error as this._onDrop is not a function. PFA.

<img width="431" alt="Screenshot 2019-12-11 at 1 33 42 PM" src="https://user-images.githubusercontent.com/13515927/70602694-fc8c4500-1c1a-11ea-919d-d4a0d7ff1470.png">
