### PR TITLE
Solves "insert Before error" issue on nested lists

### DIFF
--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -1692,7 +1692,7 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 			if (Sortable.eventCanceled) return;
 
 			// show clone at dragEl or original position
-			if (rootEl.contains(dragEl) && !this.options.group.revertClone) {
+			if (dragEl.parentNode == rootEl && !this.options.group.revertClone) {
 				rootEl.insertBefore(cloneEl, dragEl);
 			} else if (nextEl) {
 				rootEl.insertBefore(cloneEl, nextEl);


### PR DESCRIPTION
That solves an issue with nested sortables.
example of error https://jsbin.com/xabonox/edit?html,css,js
An error appears when all following conditions are met:
1)You have two nested sortable containers
2)option “pull:clone” i set at least on the parent container
3)You drag an item from the parent container into the nested container

The item is moved but not cloned and you get the error: 
“Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted”