### PR TITLE
Add 'toHierarchy()' method equivalent to 'toArray()' method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "sortablejs",
-	"version": "1.10.1",
+	"version": "1.10.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -838,9 +838,9 @@
 			}
 		},
 		"acorn": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-			"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+			"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
 			"dev": true
 		},
 		"acorn-hammerhead": {
@@ -907,43 +907,57 @@
 			}
 		},
 		"archiver": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.1.tgz",
-			"integrity": "sha1-/2YrSnggFJSj7lRNOjP+dJZQnrw=",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/archiver/-/archiver-3.1.1.tgz",
+			"integrity": "sha512-5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==",
 			"dev": true,
 			"requires": {
-				"archiver-utils": "^1.3.0",
-				"async": "^2.0.0",
+				"archiver-utils": "^2.1.0",
+				"async": "^2.6.3",
 				"buffer-crc32": "^0.2.1",
-				"glob": "^7.0.0",
-				"lodash": "^4.8.0",
-				"readable-stream": "^2.0.0",
-				"tar-stream": "^1.5.0",
-				"zip-stream": "^1.2.0"
+				"glob": "^7.1.4",
+				"readable-stream": "^3.4.0",
+				"tar-stream": "^2.1.0",
+				"zip-stream": "^2.1.2"
 			},
 			"dependencies": {
 				"async": {
-					"version": "2.6.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-					"integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+					"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
 					"dev": true,
 					"requires": {
-						"lodash": "^4.17.11"
+						"lodash": "^4.17.14"
+					}
+				},
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
 					}
 				}
 			}
 		},
 		"archiver-utils": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
-			"integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+			"integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.0",
-				"graceful-fs": "^4.1.0",
+				"glob": "^7.1.4",
+				"graceful-fs": "^4.2.0",
 				"lazystream": "^1.0.0",
-				"lodash": "^4.8.0",
-				"normalize-path": "^2.0.0",
+				"lodash.defaults": "^4.2.0",
+				"lodash.difference": "^4.5.0",
+				"lodash.flatten": "^4.4.0",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.union": "^4.6.0",
+				"normalize-path": "^3.0.0",
 				"readable-stream": "^2.0.0"
 			}
 		},
@@ -2086,13 +2100,27 @@
 			"dev": true
 		},
 		"bl": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-			"integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
+			"integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
 			"dev": true,
 			"requires": {
-				"readable-stream": "^2.3.5",
-				"safe-buffer": "^5.1.1"
+				"buffer": "^5.5.0",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.4.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"bowser": {
@@ -2161,41 +2189,19 @@
 			}
 		},
 		"buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-			"integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
+			"integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
 			"dev": true,
 			"requires": {
 				"base64-js": "^1.0.2",
 				"ieee754": "^1.1.4"
 			}
 		},
-		"buffer-alloc": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-			"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-			"dev": true,
-			"requires": {
-				"buffer-alloc-unsafe": "^1.1.0",
-				"buffer-fill": "^1.0.0"
-			}
-		},
-		"buffer-alloc-unsafe": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-			"dev": true
-		},
 		"buffer-crc32": {
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
 			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-			"dev": true
-		},
-		"buffer-fill": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
 			"dev": true
 		},
 		"buffer-from": {
@@ -2410,15 +2416,15 @@
 			"dev": true
 		},
 		"compress-commons": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
-			"integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz",
+			"integrity": "sha512-eVw6n7CnEMFzc3duyFVrQEuY1BlHR3rYsSztyG32ibGMW722i3C6IizEGMFmfMU+A+fALvBIwxN3czffTcdA+Q==",
 			"dev": true,
 			"requires": {
-				"buffer-crc32": "^0.2.1",
-				"crc32-stream": "^2.0.0",
-				"normalize-path": "^2.0.0",
-				"readable-stream": "^2.0.0"
+				"buffer-crc32": "^0.2.13",
+				"crc32-stream": "^3.0.1",
+				"normalize-path": "^3.0.0",
+				"readable-stream": "^2.3.6"
 			}
 		},
 		"concat-map": {
@@ -2489,13 +2495,26 @@
 			}
 		},
 		"crc32-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
-			"integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz",
+			"integrity": "sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==",
 			"dev": true,
 			"requires": {
 				"crc": "^3.4.4",
-				"readable-stream": "^2.0.0"
+				"readable-stream": "^3.4.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"crypto-md5": {
@@ -2712,9 +2731,9 @@
 			"dev": true
 		},
 		"end-of-stream": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
 			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
@@ -2787,9 +2806,9 @@
 			}
 		},
 		"estree-walker": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.0.tgz",
-			"integrity": "sha512-peq1RfVAVzr3PU/jL31RaOjUKLoZJpObQWJJ+LgfcxDUifyLZ1RjPQZTl0pzj2uJ45b7A7XpyppXvxdEqzo4rw==",
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+			"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
 			"dev": true
 		},
 		"esutils": {
@@ -3273,12 +3292,12 @@
 			}
 		},
 		"https-proxy-agent": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-			"integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+			"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
 			"dev": true,
 			"requires": {
-				"agent-base": "^4.1.0",
+				"agent-base": "^4.3.0",
 				"debug": "^3.1.0"
 			},
 			"dependencies": {
@@ -3680,9 +3699,9 @@
 			}
 		},
 		"kind-of": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
 			"dev": true
 		},
 		"lazystream": {
@@ -3704,9 +3723,39 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.11",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+			"dev": true
+		},
+		"lodash.defaults": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+			"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
+			"dev": true
+		},
+		"lodash.difference": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+			"integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
+			"dev": true
+		},
+		"lodash.flatten": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+			"dev": true
+		},
+		"lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+			"dev": true
+		},
+		"lodash.union": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+			"integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
 			"dev": true
 		},
 		"log-update-async-hook": {
@@ -3856,9 +3905,9 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 			"dev": true
 		},
 		"mixin-deep": {
@@ -3883,20 +3932,12 @@
 			}
 		},
 		"mkdirp": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 			"dev": true,
 			"requires": {
-				"minimist": "0.0.8"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-					"dev": true
-				}
+				"minimist": "^1.2.5"
 			}
 		},
 		"moment": {
@@ -3964,13 +4005,10 @@
 			"dev": true
 		},
 		"normalize-path": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-			"dev": true,
-			"requires": {
-				"remove-trailing-separator": "^1.0.1"
-			}
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true
 		},
 		"number-is-nan": {
 			"version": "1.0.1",
@@ -4219,9 +4257,9 @@
 			"dev": true
 		},
 		"q": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-			"integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
 			"dev": true
 		},
 		"qrcode-terminal": {
@@ -4342,12 +4380,6 @@
 					"dev": true
 				}
 			}
-		},
-		"remove-trailing-separator": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-			"dev": true
 		},
 		"repeat-element": {
 			"version": "1.1.3",
@@ -4513,13 +4545,12 @@
 			}
 		},
 		"rollup-pluginutils": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.7.1.tgz",
-			"integrity": "sha512-3nRf3buQGR9qz/IsSzhZAJyoK663kzseps8itkYHr+Z7ESuaffEPfgRinxbCRA0pf0gzLqkNKkSb8aNVTq75NA==",
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+			"integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
 			"dev": true,
 			"requires": {
-				"estree-walker": "^0.6.0",
-				"micromatch": "^3.1.10"
+				"estree-walker": "^0.6.1"
 			}
 		},
 		"safe-buffer": {
@@ -4617,9 +4648,9 @@
 			"dev": true
 		},
 		"set-value": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+			"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
@@ -4911,18 +4942,29 @@
 			}
 		},
 		"tar-stream": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-			"integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
+			"integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
 			"dev": true,
 			"requires": {
-				"bl": "^1.0.0",
-				"buffer-alloc": "^1.2.0",
-				"end-of-stream": "^1.0.0",
+				"bl": "^4.0.1",
+				"end-of-stream": "^1.4.1",
 				"fs-constants": "^1.0.0",
-				"readable-stream": "^2.3.0",
-				"to-buffer": "^1.1.1",
-				"xtend": "^4.0.0"
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"testcafe": {
@@ -5135,6 +5177,12 @@
 				"webauth": "^1.1.0"
 			},
 			"dependencies": {
+				"lodash": {
+					"version": "4.17.11",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+					"dev": true
+				},
 				"nanoid": {
 					"version": "0.2.2",
 					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-0.2.2.tgz",
@@ -5256,12 +5304,6 @@
 				"os-tmpdir": "~1.0.1"
 			}
 		},
-		"to-buffer": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-			"integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-			"dev": true
-		},
 		"to-fast-properties": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -5320,9 +5362,9 @@
 			}
 		},
 		"tree-kill": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
-			"integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+			"integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
 			"dev": true
 		},
 		"trim-right": {
@@ -5420,38 +5462,15 @@
 			"dev": true
 		},
 		"union-value": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+			"integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
 			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"get-value": "^2.0.6",
 				"is-extendable": "^0.1.1",
-				"set-value": "^0.4.3"
-			},
-			"dependencies": {
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
-					"requires": {
-						"is-extendable": "^0.1.0"
-					}
-				},
-				"set-value": {
-					"version": "0.4.3",
-					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.1",
-						"to-object-path": "^0.3.0"
-					}
-				}
+				"set-value": "^2.0.1"
 			}
 		},
 		"unset-value": {
@@ -5581,27 +5600,27 @@
 			}
 		},
 		"wd": {
-			"version": "1.11.2",
-			"resolved": "https://registry.npmjs.org/wd/-/wd-1.11.2.tgz",
-			"integrity": "sha512-zXJY9ARjQQYN2LatLTRcW39EYzIVqKNhGpp4XWJmRgHBioG4FoenIOsoVbaO8lnFGgv31V99kAy5hB4eWGIwzA==",
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/wd/-/wd-1.12.1.tgz",
+			"integrity": "sha512-O99X8OnOgkqfmsPyLIRzG9LmZ+rjmdGFBCyhGpnsSL4MB4xzHoeWmSVcumDiQ5QqPZcwGkszTgeJvjk2VjtiNw==",
 			"dev": true,
 			"requires": {
-				"archiver": "2.1.1",
-				"async": "2.0.1",
-				"lodash": "4.17.11",
+				"archiver": "^3.0.0",
+				"async": "^2.0.0",
+				"lodash": "^4.0.0",
 				"mkdirp": "^0.5.1",
-				"q": "1.4.1",
+				"q": "^1.5.1",
 				"request": "2.88.0",
-				"vargs": "0.1.0"
+				"vargs": "^0.1.0"
 			},
 			"dependencies": {
 				"async": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
-					"integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+					"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
 					"dev": true,
 					"requires": {
-						"lodash": "^4.8.0"
+						"lodash": "^4.17.14"
 					}
 				}
 			}
@@ -5676,12 +5695,6 @@
 				"ultron": "~1.1.0"
 			}
 		},
-		"xtend": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-			"dev": true
-		},
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
@@ -5689,15 +5702,27 @@
 			"dev": true
 		},
 		"zip-stream": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
-			"integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.3.tgz",
+			"integrity": "sha512-EkXc2JGcKhO5N5aZ7TmuNo45budRaFGHOmz24wtJR7znbNqDPmdZtUauKX6et8KAVseAMBOyWJqEpXcHTBsh7Q==",
 			"dev": true,
 			"requires": {
-				"archiver-utils": "^1.3.0",
-				"compress-commons": "^1.2.0",
-				"lodash": "^4.8.0",
-				"readable-stream": "^2.0.0"
+				"archiver-utils": "^2.1.0",
+				"compress-commons": "^2.1.1",
+				"readable-stream": "^3.4.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		}
 	}

--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -1590,14 +1590,14 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 	_toHierarchy: function( el ) {
 		let order = [],
 			children = el.children,
-			n = children.length;
+			n = children.length,
+			options = this.options;
 		for( let i = 0; i < n; ++i ) {
 			let child = children[i],
 				grandChildren = child.children,
 				m = grandChildren.length;
 			// I am not sure about this closest() call if the 3rd
-			// argument should be this.el or the local el?
-			// It was this.el and I changed it to just el
+			// argument should be 'this.el' or the local 'el'?
 			if( closest( child, options.draggable, el, false ) ) {
 				order.push( child.getAttribute(options.dataIdAttr) || _generateId(child) );
 			}
@@ -1625,7 +1625,7 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 		    recursionClasses = this.options.recursionClasses || [],
 		    recursionIds = this.options.recursionIds || [];
 		if( !el ) return false;
-		if( recusionTags.include( el.nodeName ) ) return true;
+		if( recursionTags.includes( el.nodeName ) ) return true;
 		if( el.id && el.id != 'undefined' && recursionIds.includes( el.id ) ) return true;
 		let classList = el.className.split(' ');
 		for( let i = 0; i < recursionClasses.length; ++i ) {

--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -394,9 +394,9 @@ function Sortable(el, options) {
 		fallbackOffset: {x: 0, y: 0},
 		supportPointer: Sortable.supportPointer !== false && ('PointerEvent' in window),
 		emptyInsertThreshold: 5,
-		recursionTags = [ "UL", "OL" ],
-		recursionClasses = [],
-		recursionIds = [];
+		recursionTags: [ "UL", "OL" ],
+		recursionClasses: [],
+		recursionIds: []
 	};
 
 	PluginManager.initializePlugins(this, el, defaults);
@@ -1626,13 +1626,13 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 		    recursionIds = this.options.recursionIds || [];
 		if( !el ) return false;
 		if( recusionTags.include( el.nodeName ) ) return true;
-		if( el.id && el.id != 'undefined' && recursionIds.includes( el.id ) return true;
+		if( el.id && el.id != 'undefined' && recursionIds.includes( el.id ) ) return true;
 		let classList = el.className.split(' ');
 		for( let i = 0; i < recursionClasses.length; ++i ) {
-			if( classList.includes( recursionClasses[i] ) return true;
+			if( classList.includes( recursionClasses[i] ) ) return true;
 		}
 		return false;
-	}
+	},
 
 
 	/**


### PR DESCRIPTION
I was using nested Sortable elements and needed a way to easily dump the hierarchy. The added method is analogous to 'toArray()' except that it includes both ids of the Sortable element and all its nested lists.

This is only new code, three new options and three new methods so should not change other functionality.