### PR TITLE
Fix IE11 "SCRIPT16389: Unspecified error." when dragging element

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -178,7 +178,7 @@ function getRect(el, relativeToContainingBlock, relativeToNonStaticParent, undoS
 		height,
 		width;
 
-	if (el !== window && el !== getWindowScrollingElement()) {
+	if (el !== window && el.parentNode && el !== getWindowScrollingElement()) {
 		elRect = el.getBoundingClientRect();
 		top = elRect.top;
 		left = elRect.left;


### PR DESCRIPTION
IE11 throws error "SCRIPT16389: Unspecified error." when dragging element after `Sortable.create(...)` was executed more than 1 time while in same page (without page reload).
This issue happens also in Sortable earlier versions, and due to this error may stop Sortable functionality at all.

Using `el.parentNode` for simplest fix checking if element sort of exists in DOM (by checking if parent element exists). Universal fix would be to use `document.body.contains(el)`, but I think it is too much here and would cause small performance impact, that's way fixing it is simple way.