### PR TITLE
fix(plugins): ignore mounting duplicate plugins

### DIFF
--- a/packages/sortable/src/PluginManager.ts
+++ b/packages/sortable/src/PluginManager.ts
@@ -12,7 +12,11 @@ const pluginManager = {
         plugin[option] = defaults[option];
       }
     }
-    plugins.push(plugin);
+
+    //  only add plugins once, even if they're mounted multiple times
+    if (!plugins.map((p) => p.name).includes(plugin.name)) {
+      plugins.push(plugin);
+    }
   },
   pluginEvent(eventName, sortable, evt) {
     this.eventCanceled = false;


### PR DESCRIPTION
closes #1581

@beljand Thank you making these changes.
We had a repo refactor and it broke your PR so I made the PR. All credit to you!  :)
