### PR TITLE
Fix logic to check the last horizontal ghost in element

### DIFF
--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -1769,7 +1769,7 @@ function _ghostIsLast(evt, vertical, sortable) {
 
 	return vertical ?
 		(evt.clientX > rect.right + spacer || evt.clientX <= rect.right && evt.clientY > rect.bottom && evt.clientX >= rect.left) :
-		(evt.clientX > rect.right && evt.clientY > rect.top || evt.clientX <= rect.right && evt.clientY > rect.bottom + spacer);
+		(evt.clientX > rect.right && evt.clientY > rect.top && evt.clientY < rect.bottom + spacer);
 }
 
 function _getSwapDirection(evt, target, targetRect, vertical, swapThreshold, invertedSwapThreshold, invertSwap, isLastTarget) {


### PR DESCRIPTION
While using Sortablejs, I noticed a symptom of objects not moving as intended.
Assuming that there are 3 objects arranged horizontally, when dragging the first object to the second object, sometimes it is recognized as the last object and added at the end.