### PR TITLE
Trick for emptyInsertThreshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,19 +521,16 @@ The distance (in pixels) the mouse must be from an empty sortable while dragging
 
 Demo: https://jsbin.com/becavoj/edit?js,output
 
-Instead of this, you can just set a padding on your list when it is empty. Warning, for :empty to work, it must have no node inside (even text one).
-(It will help if your lists are side-by-side, since you only want the drag occurs when you are under the list - not at the left)
-
-Adding a CSS rule :
+An alternative to this option would be to set a padding on your list when it is empty.
+For example:
 `ul:empty {
-  background:pink;
-  padding-bottom:3em;
+  padding-bottom: 20px;
 }`
 
-And rewriting the empty list as : `<ul id="list2" class="list-group"></ul>` (so that it is really empty)
+Warning: For :empty to work, it must have no node inside (even text one).
 
-You got :
-https://jsbin.com/galujuvayi/edit?html,css,js,output
+Demo:
+https://jsbin.com/yunakeg/edit?html,css,js,output
 
 ---
 ### Event object ([demo](https://jsbin.com/fogujiv/edit?js,output))

--- a/README.md
+++ b/README.md
@@ -522,12 +522,15 @@ The distance (in pixels) the mouse must be from an empty sortable while dragging
 Demo: https://jsbin.com/becavoj/edit?js,output
 
 An alternative to this option would be to set a padding on your list when it is empty.
-For example:
-`ul:empty {
-  padding-bottom: 20px;
-}`
 
-Warning: For :empty to work, it must have no node inside (even text one).
+For example:
+```css
+ul:empty {
+  padding-bottom: 20px;
+}
+```
+
+Warning: For `:empty` to work, it must have no node inside (even text one).
 
 Demo:
 https://jsbin.com/yunakeg/edit?html,css,js,output

--- a/README.md
+++ b/README.md
@@ -521,6 +521,19 @@ The distance (in pixels) the mouse must be from an empty sortable while dragging
 
 Demo: https://jsbin.com/becavoj/edit?js,output
 
+Instead of this, you can just set a padding on your list when it is empty. Warning, for :empty to work, it must have no node inside (even text one).
+(It will help if your lists are side-by-side, since you only want the drag occurs when you are under the list - not at the left)
+
+Adding a CSS rule :
+`ul:empty {
+  background:pink;
+  padding-bottom:3em;
+}`
+
+And rewriting the empty list as : `<ul id="list2" class="list-group"></ul>` (so that it is really empty)
+
+You got :
+https://jsbin.com/galujuvayi/edit?html,css,js,output
 
 ---
 ### Event object ([demo](https://jsbin.com/fogujiv/edit?js,output))


### PR DESCRIPTION
Hi,

The emptyInsertThreshold is not really needed (at least in recent browsers), as the function can be obtained by a pure css solution.

I propose this in the README - of course you're free to rewrite it and/or put it somewhere else.

Other ideas :
- Managing automatically an "empty" class when the list is empty (not relying on the :empty which works only if there's no node at all, even text ones)
- Have an "emptyPadding" option, adding automatically padding on an empty list. Note that the required padding can be bottom and/or right, or even top and/or left