### PR TITLE
avoid implicit deselect on outside click

### DIFF
--- a/plugins/MultiDrag/MultiDrag.js
+++ b/plugins/MultiDrag/MultiDrag.js
@@ -35,11 +35,13 @@ function MultiDragPlugin() {
 			}
 		}
 
-		if (sortable.options.supportPointer) {
-			on(document, 'pointerup', this._deselectMultiDrag);
-		} else {
-			on(document, 'mouseup', this._deselectMultiDrag);
-			on(document, 'touchend', this._deselectMultiDrag);
+		if (!sortable.options.avoidImplicitDeselect) {
+			if (sortable.options.supportPointer) {
+				on(document, 'pointerup', this._deselectMultiDrag);
+			} else {
+				on(document, 'mouseup', this._deselectMultiDrag);
+				on(document, 'touchend', this._deselectMultiDrag);
+			}
 		}
 
 		on(document, 'keydown', this._checkKeyDown);
@@ -48,6 +50,7 @@ function MultiDragPlugin() {
 		this.defaults = {
 			selectedClass: 'sortable-selected',
 			multiDragKey: null,
+			avoidImplicitDeselect: false,
 			setData(dataTransfer, dragEl) {
 				let data = '';
 				if (multiDragElements.length && multiDragSortable === sortable) {

--- a/plugins/MultiDrag/README.md
+++ b/plugins/MultiDrag/README.md
@@ -27,7 +27,8 @@ new Sortable(el, {
 	multiDrag: true, // Enable the plugin
 	selectedClass: "sortable-selected", // Class name for selected item
 	multiDragKey: null, // Key that must be down for items to be selected
-
+	avoidImplicitDeselect: true, // true - if you don't want to deselect items on outside click
+	
 	// Called when an item is selected
 	onSelect: function(/**Event*/evt) {
 		evt.item // The selected item


### PR DESCRIPTION
https://github.com/SortableJS/Sortable/issues/1612
Added a key to the MultiDragPlugin to avoid canceling selected items when clicking outside the block