### PR TITLE
Prevent ignored touches on Android Chrome.

### DIFF
--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -298,7 +298,7 @@ let dragEl,
 
 
 // #1184 fix - Prevent click event on fallback if dragged but item not changed position
-if (documentExists) {
+if (documentExists && !ChromeForAndroid) {
 	document.addEventListener('click', function(evt) {
 		if (ignoreNextClick) {
 			evt.preventDefault();


### PR DESCRIPTION
Android Chrome will not trigger a click event if a user drags an item,
even if the item is dropped back into its original placement. This
means that whenever the "ignore next click" handling is activated, the
user's _next_ click (unrelated to dragging) will be ignored.

This commit solves this by never activating the "ignore next click"
handling on Android Chrome.