### PR TITLE
fix: compatible with shadowNode on touch event

### DIFF
--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -780,7 +780,7 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 					target = parent; // store last element
 				}
 				/* jshint boss:true */
-				while (parent = parent.parentNode);
+				while (parent = parent.parentNode || parent.getRootNode().host);
 			}
 
 			_unhideGhostForTarget();


### PR DESCRIPTION
Compatible with the shadowDOM when users trigger touch events.

Previously it uses `.parentNode` to get the parent node, but if it's a shadowNode, it could get a null. So add the `.getRootNode().host` to get shadowDOM root node when got null.

Here is a repro sandbox: https://stackblitz.com/edit/typescript-tuvyqs?file=mySortable.js
You can confirm it by removing the addition code in line 1953.