### PR TITLE
fix: multidragkey not working as stated in docs

### DIFF
--- a/plugins/MultiDrag/MultiDrag.js
+++ b/plugins/MultiDrag/MultiDrag.js
@@ -309,10 +309,7 @@ function MultiDragPlugin() {
 				children = parentEl.children;
 
 			// Multi-drag selection
-			if (!dragStarted) {
-				if (options.multiDragKey && !this.multiDragKeyDown) {
-					this._deselectMultiDrag();
-				}
+			if (!dragStarted && (!options.multiDragKey || this.multiDragKeyDown)) {
 				toggleClass(dragEl, options.selectedClass, !~multiDragElements.indexOf(dragEl));
 
 				if (!~multiDragElements.indexOf(dragEl)) {


### PR DESCRIPTION
According to [the docs](https://github.com/SortableJS/Sortable/tree/master/plugins/MultiDrag#multidragkey-option): The multiDragKey is "a custom keyboard key may be designated as having to be down for the user to be able to select multi-drag elements."

At the moment, MultiDrag allows user to select a single element even if `multiDragKey` is not down, if set. With this change, `mutliDragKey` has to be down to select even one element.