### PR TITLE
Add option for reverting DOM modifications

### DIFF
--- a/src/EventDispatcher.js
+++ b/src/EventDispatcher.js
@@ -5,7 +5,7 @@ import PluginManager from './PluginManager.js';
 export default function dispatchEvent(
 	{
 		sortable, rootEl, name,
-		targetEl, cloneEl, toEl, fromEl,
+		targetEl, cloneEl, toEl, toSortable, fromEl, fromSortable,
 		oldIndex, newIndex,
 		oldDraggableIndex, newDraggableIndex,
 		originalEvent, putSortable, extraEventProperties
@@ -29,7 +29,9 @@ export default function dispatchEvent(
 	}
 
 	evt.to = toEl || rootEl;
+	evt.toSortable = toSortable || undefined;
 	evt.from = fromEl || rootEl;
+	evt.fromSortable = fromSortable || undefined;
 	evt.item = targetEl || rootEl;
 	evt.clone = cloneEl;
 

--- a/src/EventDispatcher.js
+++ b/src/EventDispatcher.js
@@ -8,7 +8,8 @@ export default function dispatchEvent(
 		targetEl, cloneEl, toEl, toSortable, fromEl, fromSortable,
 		oldIndex, newIndex,
 		oldDraggableIndex, newDraggableIndex,
-		originalEvent, putSortable, extraEventProperties
+		originalEvent, putSortable, extraEventProperties,
+		originalAllEventProperties
 	}
 ) {
 	sortable = (sortable || (rootEl && rootEl[expando]));
@@ -46,7 +47,7 @@ export default function dispatchEvent(
 
 	let allEventProperties = { ...extraEventProperties, ...PluginManager.getEventProperties(name, sortable) };
 	for (let option in allEventProperties) {
-		evt[option] = allEventProperties[option];
+		evt[option] = originalAllEventProperties ? originalAllEventProperties[option] : allEventProperties[option];
 	}
 
 	if (rootEl) {

--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -358,6 +358,7 @@ function Sortable(el, options) {
 
 	let defaults = {
 		group: null,
+		revertDOM: false,
 		sort: true,
 		disabled: false,
 		store: null,
@@ -1426,12 +1427,31 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 				if (rootEl !== parentEl) {
 
 					if (newIndex >= 0) {
+						// drag from one list and drop into another
+
+						/* ----- */
+
+						if (parentEl[expando].options.revertDOM) {
+							parentEl.removeChild(dragEl);
+						}
+
+						if (rootEl[expando].options.revertDOM) {
+							rootEl.insertBefore(dragEl, rootEl.children[oldIndex]);
+							if (putSortable.lastPutMode === 'clone') {
+								rootEl.removeChild(cloneEl);
+							}
+						}
+
+						/* ----- */
+
 						// Add event
 						_dispatchEvent({
 							rootEl: parentEl,
 							name: 'add',
 							toEl: parentEl,
+							toSortable: parentEl[expando],
 							fromEl: rootEl,
+							fromSortable: rootEl[expando],
 							originalEvent: evt
 						});
 
@@ -1440,24 +1460,31 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 							sortable: this,
 							name: 'remove',
 							toEl: parentEl,
+							toSortable: parentEl[expando],
 							originalEvent: evt
 						});
 
-						// drag from one list and drop into another
-						_dispatchEvent({
-							rootEl: parentEl,
-							name: 'sort',
-							toEl: parentEl,
-							fromEl: rootEl,
-							originalEvent: evt
-						});
+						if (!parentEl[expando].options.revertDOM) {
+							_dispatchEvent({
+								rootEl: parentEl,
+								name: 'sort',
+								toEl: parentEl,
+								toSortable: parentEl[expando],
+								fromEl: rootEl,
+								fromSortable: rootEl[expando],
+								originalEvent: evt
+							});
+						}
 
-						_dispatchEvent({
-							sortable: this,
-							name: 'sort',
-							toEl: parentEl,
-							originalEvent: evt
-						});
+						if (!rootEl[expando].options.revertDOM) {
+							_dispatchEvent({
+								sortable: this,
+								name: 'sort',
+								toEl: parentEl,
+								toSortable: parentEl[expando],
+								originalEvent: evt
+							});
+						}
 					}
 
 					putSortable && putSortable.save();
@@ -1465,10 +1492,24 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 					if (newIndex !== oldIndex) {
 						if (newIndex >= 0) {
 							// drag & drop within the same list
+
+							/* ----- */
+
+							if (parentEl[expando].options.revertDOM) {
+								parentEl.removeChild(dragEl);
+							}
+
+							if (rootEl[expando].options.revertDOM) {
+								rootEl.insertBefore(dragEl, rootEl.children[oldIndex]);
+							}
+
+							/* ----- */
+
 							_dispatchEvent({
 								sortable: this,
 								name: 'update',
 								toEl: parentEl,
+								toSortable: parentEl[expando],
 								originalEvent: evt
 							});
 
@@ -1476,6 +1517,7 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 								sortable: this,
 								name: 'sort',
 								toEl: parentEl,
+								toSortable: parentEl[expando],
 								originalEvent: evt
 							});
 						}


### PR DESCRIPTION
This option allows to use Sortable.js with any framework that handles the DOM manipulation by state (React, Vue, Svelte...). Toggling the option 'revertDOM' to 'true' will let you handle your own state manipulation by the Sortable events (onAdd, onSort...). Now the events also receive the Sortable object, allowing access to the 'to' and 'from' group names and other properties.

This PR mainly solves: #546 #1931 #1856 #1874
And probably solves: #2024 #837 #781

## I get it...

I get that the main purpose of Sortable.js is for DOM manipulation (addressed on mostly all issues tagged). However **I enjoy a lot** the workflow using Sortable and as far I can see a lot of people opening similar issues too.

So this is an attempt to implement the feature in a little less hacky way (or [as hacky](https://github.com/SortableJS/Sortable/issues/546#issuecomment-150835607) but built in the library) to unlock the usability of Sortable in this kind of data/state driven frameworks without framework-targeted alternatives.

# This is not fully tested

I only tested slightly in Svelte and with MultiDrag Plugin. I would love the community to test on its own use cases and suggest changes. Mainly create a discussion beyond just saying Sortable is not meant for this.

Thanks a lot for maintaining Sortable alive! I will post a Svelte example in the first comment.

# Known issues

- MultiDrag BUG: Due to bug #2203 , sorting on a certain way won't fire the onSort event, hence breaking the state-DOM coherence, hence breaking the whole Sortable container state.
- MultiDrag BUG **(Svelte only)**: dragging and dropping before folding-animation ends will only move the draggingEl and leave behind all other elements. Temporal solution: take the dropped index and count from there to insert to the other array.