### PR TITLE
docs: remove dollar sign from code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ Demo: http://sortablejs.github.io/Sortable/
 
 Install with NPM:
 ```bash
-$ npm install sortablejs --save
+npm install sortablejs --save
 ```
 
 Install with Bower:
 ```bash
-$ bower install --save sortablejs
+bower install --save sortablejs
 ```
 
 Import into your project:


### PR DESCRIPTION
For code blocks on github there is a button that lets you copy the input. Before it would include the dollar sign which would not work in the terminal

example before:
$ npm install sortablejs --save

after:
npm install sortablejs --save