### PR TITLE
fix: set the target as the host element when target contains a shadowRoot

### DIFF
--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -36,7 +36,7 @@ import {
 	clone,
 	expando,
 	getChildContainingRectFromElement,
-	getParentOrHost,
+	getParentOrHost
 } from './utils.js';
 
 

--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -755,6 +755,10 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 
 			while (target && target.shadowRoot) {
 				target = target.shadowRoot.elementFromPoint(touchEvt.clientX, touchEvt.clientY);
+				const host = target.getRootNode().host;
+				if (host) {
+					target = host;
+				}
 				if (target === parent) break;
 				parent = target;
 			}

--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -35,7 +35,8 @@ import {
 	scrollBy,
 	clone,
 	expando,
-	getChildContainingRectFromElement
+	getChildContainingRectFromElement,
+	getParentOrHost,
 } from './utils.js';
 
 
@@ -755,10 +756,6 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 
 			while (target && target.shadowRoot) {
 				target = target.shadowRoot.elementFromPoint(touchEvt.clientX, touchEvt.clientY);
-				const host = target.getRootNode().host;
-				if (host) {
-					target = host;
-				}
 				if (target === parent) break;
 				parent = target;
 			}
@@ -785,7 +782,7 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 					target = parent; // store last element
 				}
 				/* jshint boss:true */
-				while (parent = parent.parentNode);
+				while (parent = getParentOrHost(parent));
 			}
 
 			_unhideGhostForTarget();


### PR DESCRIPTION
## Fix for sorting elements that contain web components

See https://github.com/SortableJS/Sortable/issues/2346 for explanation and code samples of the issue.

When sortable elements contain web components with shadowRoot, and forceFallback is enabled, swapping elements is not working correctly.

DOM Example:

```
<ul id="list" class="list-group">
  <li class="list-group-item"><custom-handle></custom-handle><custom-content></custom-content></li>
 <li class="list-group-item"><custom-handle></custom-handle><custom-content></custom-content></li>
</li>
```