### PR TITLE
Add option to specify whether to ignore next click on fallback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ var sortable = new Sortable(el, {
 	fallbackClass: "sortable-fallback",  // Class name for the cloned DOM Element when using forceFallback
 	fallbackOnBody: false,  // Appends the cloned DOM Element into the Document's Body
 	fallbackTolerance: 0, // Specify in pixels how far the mouse should move before it's considered as a drag.
+	ignoreNextClickOnFallback: true, // Specify whether to ignore next click on fallback.
 
 	dragoverBubble: false,
 	removeCloneOnHide: true, // Remove the clone element when it is not showing, rather than just hiding it

--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -393,6 +393,7 @@ function Sortable(el, options) {
 		fallbackClass: 'sortable-fallback',
 		fallbackOnBody: false,
 		fallbackTolerance: 0,
+		ignoreNextClickOnFallback: true,
 		fallbackOffset: {x: 0, y: 0},
 		supportPointer: Sortable.supportPointer !== false && ('PointerEvent' in window) && !Safari,
 		emptyInsertThreshold: 5
@@ -958,7 +959,7 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 
 		// Set proper drop events
 		if (fallback) {
-			ignoreNextClick = true;
+			ignoreNextClick = options.ignoreNextClickOnFallback;
 			_this._loopId = setInterval(_this._emulateDragOver, 50);
 		} else {
 			// Undo what was set in _prepareDragStart before drag started


### PR DESCRIPTION
Currentry, prevent click event on fallback if dragged but item not changed position.
For simple HTML Structure, I think that disabling this behavior will not cause any problems.
So, i will modify it so that it can be switched as an option.
See #2352 #2319.