### PR TITLE
fix: Since the click event does not occur after the touchmove event, set ignoreNextClick to false during touchmove.

### DIFF
--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -958,7 +958,7 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 
 		// Set proper drop events
 		if (fallback) {
-			ignoreNextClick = true;
+			ignoreNextClick = evt.type !== 'touchmove';
 			_this._loopId = setInterval(_this._emulateDragOver, 50);
 		} else {
 			// Undo what was set in _prepareDragStart before drag started


### PR DESCRIPTION
See #2352 #2319.

The following behavior can be reproduced in chrome's smartphone display mode and on the actual device.

When dragging and dropping with the mouse, the click event is executed after the drop. (mousemove)
However, on a smartphone, the click event is not executed after a drop. (touchmove)
Therefore, when fallback is executed on a smartphone, the behavior of pressing a button after a drop is disabled.

To solve this problem, set the ignoreNextClick flag to false for the touchmove event so that the click event is not disabled.

Demo:
https://codepen.io/armdbmfg-the-scripter/pen/NWmLJeL


https://github.com/SortableJS/Sortable/assets/5924971/60928628-ba2a-4ce3-a547-0d1c394b0532

