### PR TITLE
Add rtl support

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ var sortable = new Sortable(el, {
 	invertSwap: false, // Will always use inverted swap zone if set to true
 	invertedSwapThreshold: 1, // Threshold of the inverted swap zone (will be set to swapThreshold value by default)
 	direction: 'horizontal', // Direction of Sortable (will be detected automatically if not given)
+	rtl: false, // If Sortable is written right to left (will be detected automatically if not given)
 
 	forceFallback: false,  // ignore the HTML5 DnD behaviour and force the fallback to kick in
 
@@ -339,7 +340,10 @@ Sortable.create(el, {
 
 
 ---
+#### `rtl` option
+Set to `true` if sorting direction is right to left (including `flex-direction: row-reverse`). Can be set to `true`, `false`, or a function, which will be called whenever a target is dragged over. Must return `true` or `false`.
 
+---
 
 #### `touchStartThreshold` option
 This option is similar to `fallbackTolerance` option.

--- a/tests/Sortable.test.js
+++ b/tests/Sortable.test.js
@@ -384,3 +384,39 @@ test('Do not insert into empty list if outside emptyInsertThreshold', async brow
 		})
 		.expect(dragStartPosition.innerText).eql(dragEl.innerText);
 });
+
+
+fixture `Right to left`
+	.page `./rtl-list.html`;
+
+test('Sort left list', async browser => {
+	const dragStartPosition = list1.child(0);
+	const dragEl = await dragStartPosition();
+	const dragEndPosition = list1.child(2);
+	const targetStartPosition = list1.child(2);
+	const target = await targetStartPosition();
+	const targetEndPosition = list1.child(1);
+
+	await browser
+		.expect(dragStartPosition.innerText).eql(dragEl.innerText)
+		.expect(targetStartPosition.innerText).eql(target.innerText)
+		.dragToElement(dragEl, target)
+		.expect(dragEndPosition.innerText).eql(dragEl.innerText)
+		.expect(targetEndPosition.innerText).eql(target.innerText);
+});
+
+test('Sort right list', async browser => {
+	const dragStartPosition = list1.child(2);
+	const dragEl = await dragStartPosition();
+	const dragEndPosition = list1.child(0);
+	const targetStartPosition = list1.child(0);
+	const target = await targetStartPosition();
+	const targetEndPosition = list1.child(1);
+
+	await browser
+		.expect(dragStartPosition.innerText).eql(dragEl.innerText)
+		.expect(targetStartPosition.innerText).eql(target.innerText)
+		.dragToElement(dragEl, target)
+		.expect(dragEndPosition.innerText).eql(dragEl.innerText)
+		.expect(targetEndPosition.innerText).eql(target.innerText);
+});

--- a/tests/rtl-list.html
+++ b/tests/rtl-list.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<title></title>
+	<link rel="stylesheet" type="text/css" href="./style.css">
+	<style>
+		.list {
+			display: flex;
+			direction: rtl;
+			gap: 10px;
+		}
+	</style>
+</head>
+
+<body>
+
+	<div class="list" id="list1">
+		<div>Item 1.1</div>
+		<div>Item 1.2</div>
+		<div>Item 1.3</div>
+		<div>Item 1.4</div>
+		<div>Item 1.5</div>
+	</div>
+
+
+	<script src="../Sortable.js"></script>
+
+	<script type="text/javascript">
+		new Sortable(document.getElementById('list1'));
+	</script>
+
+</body>
+
+</html>


### PR DESCRIPTION
I added a option to specify if Sortable should use rtl. If not given, detect automatically with css direction or flex-direction: row-reverse. I also changed the _getDirection function to a more generic function that could be used both to get direction value and to get rtl value. Hope it'll be helpful!
Enjoy your day