### PR TITLE
Fixes leaky savedInputChecked across multiple instances

### DIFF
--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -1539,7 +1539,9 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 		Sortable.active = null;
 
 		savedInputChecked.forEach(function (el) {
-			el.checked = true;
+			if (this.el.contains(el)) {
+			        el.checked = true;
+			}
 		});
 
 		savedInputChecked.length =


### PR DESCRIPTION
### Steps to Reproduce Issue

1) Create two sortables on the same page: List A and List B

2) Add an event when a checkbox is unchecked inside List A

3) Set event to destroy and replace SortableJS on List B 

### Problem

All checkboxes on List A are rechecked when List B is rebound (via `_nulling`)

![SortableJS-Bug](https://github.com/SortableJS/Sortable/assets/1392869/e8fc26f2-ac99-4845-a7d8-2b35438991fd)

### Expectation

The checkbox should remain unchecked

### Proposed Fix

It seems to happen because `savedInputChecked` is a global instance. So List B's store will contain List A's checkboxes...

The proposed code ensures the checkboxes remain within the scope of the relevant instance.

### Related

This may be a solution to #1052's continuation since people are still suggesting it's broken.

It could be why you can't reproduce it, since two SortableJS instances are needed to produce the collision/outcome.