### PR TITLE
Prevent attaching touchmove event listener on document all the time

### DIFF
--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -691,6 +691,7 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 		if (!this.nativeDraggable || touch) {
 			if (this.options.supportPointer) {
 				on(document, 'pointermove', this._onTouchMove);
+				on(document, 'touchmove', this._preventTouchMove);
 			} else if (touch) {
 				on(document, 'touchmove', this._onTouchMove);
 			} else {
@@ -846,6 +847,12 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 			}
 
 			evt.cancelable && evt.preventDefault();
+		}
+	},
+
+	_preventTouchMove: function (/**TouchEvent*/evt) {
+		if (evt.cancelable) {
+			evt.preventDefault();
 		}
 	},
 
@@ -1322,6 +1329,7 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 		off(document, 'mousemove', this._onTouchMove);
 		off(document, 'touchmove', this._onTouchMove);
 		off(document, 'pointermove', this._onTouchMove);
+		off(document, 'touchmove', this._preventTouchMove);
 		off(document, 'dragover', nearestEmptyInsertDetectEvent);
 		off(document, 'mousemove', nearestEmptyInsertDetectEvent);
 		off(document, 'touchmove', nearestEmptyInsertDetectEvent);
@@ -1932,16 +1940,6 @@ function _nextTick(fn) {
 function _cancelNextTick(id) {
 	return clearTimeout(id);
 }
-
-// Fixed #973:
-if (documentExists) {
-	on(document, 'touchmove', function(evt) {
-		if ((Sortable.active || awaitingDragStarted) && evt.cancelable) {
-			evt.preventDefault();
-		}
-	});
-}
-
 
 // Export utils
 Sortable.utils = {

--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -691,12 +691,12 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 		if (!this.nativeDraggable || touch) {
 			if (this.options.supportPointer) {
 				on(document, 'pointermove', this._onTouchMove);
-				on(document, 'touchmove', this._preventTouchMove);
 			} else if (touch) {
 				on(document, 'touchmove', this._onTouchMove);
 			} else {
 				on(document, 'mousemove', this._onTouchMove);
 			}
+			on(document, 'touchmove', this._preventTouchMove);
 		} else {
 			on(dragEl, 'dragend', this);
 			on(rootEl, 'dragstart', this._onDragStart);


### PR DESCRIPTION
Reference: https://github.com/SortableJS/Sortable/issues/973#issuecomment-406593777

This PR moves it to only be attached during dragging like our other event handlers