### PR TITLE
unmounted dragEl from previous target who is dragging over a new targ…

### DIFF
--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -336,7 +336,7 @@ let nearestEmptyInsertDetectEvent = function(evt) {
 
 let _checkOutsideTargetEl = function(evt) {
 	if (dragEl) {
-		dragEl.parentNode[expando]._isOutsideThisEl(evt.target);
+		dragEl.parentNode && dragEl.parentNode[expando]._isOutsideThisEl(evt.target);
 	}
 };
 
@@ -774,7 +774,7 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 				parent = target;
 			}
 
-			dragEl.parentNode[expando]._isOutsideThisEl(target);
+			dragEl.parentNode && dragEl.parentNode[expando]._isOutsideThisEl(target);
 
 			if (parent) {
 				do {
@@ -1101,7 +1101,7 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 
 			// no bubbling and not fallback
 			if (!options.dragoverBubble && !evt.rootEl && target !== document) {
-				dragEl.parentNode[expando]._isOutsideThisEl(evt.target);
+				dragEl.parentNode && dragEl.parentNode[expando]._isOutsideThisEl(evt.target);
 
 				// Do not detect for empty insert if already inserted
 				!insertion && nearestEmptyInsertDetectEvent(evt);
@@ -1326,6 +1326,13 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 
 			if (el.contains(dragEl)) {
 				return completed(false);
+			}
+		} else {
+			// unmounted dragEl from previous target who is dragging over a new target but can not be dropped
+			if (putSortable.lastPutMode !== 'clone') {
+				rootEl.appendChild(dragEl);
+			} else if (rootEl !== dragEl.parentNode) {
+				dragEl.parentNode && dragEl.parentNode.removeChild(dragEl);
 			}
 		}
 


### PR DESCRIPTION
If there are more than two instance lists of  sortable. The one you drag over can not be dropped, but another you pass over has mounted the dragEl.If you want unmounted it, you need this fix.