### PR TITLE
provide newIndex value in onDrop event

### DIFF
--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -1436,8 +1436,8 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 					sortable: this,
 					name: 'unchoose',
 					toEl: parentEl,
-					newIndex: null,
-					newDraggableIndex: null,
+					newIndex: newIndex,
+					newDraggableIndex: newDraggableIndex,
 					originalEvent: evt
 				});
 


### PR DESCRIPTION
Hi there,

This is a really simple patch that solves a small problem I was having with the library.

I check `if (event.oldIndex == event.newIndex && event.to == event.from)` to determine if the item was actually moved, or just picked up and put down. The event always provided null for `newIndex`, so it was impossible to tell. Using the `newIndex` variable provided just above where the event is fired allowed me use this logic.

Previously, null was always provided for this event. I do not know why, or if it was necessary, but in my use case this fixed the problem and I haven't noticed any other issues. The usage guide in the readme says that this value *should* include the `newIndex` of the item, so I think that always providing null was unintended.