### PR TITLE
Fix: Sortable Freezes Browser (Shadow DOM)

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -38,7 +38,7 @@ function matches(/**HTMLElement*/el, /**String*/selector) {
 }
 
 function getParentOrHost(el) {
-	return (el.host && el !== document && el.host.nodeType)
+	return (el.host && el !== document && el.host.nodeType && el.host !== el)
 		? el.host
 		: el.parentNode;
 }
@@ -256,7 +256,7 @@ function getRect(el, relativeToContainingBlock, relativeToNonStaticParent, undoS
 
 /**
  * Returns the content rect of the element (bounding rect minus border and padding)
- * @param {HTMLElement} el 
+ * @param {HTMLElement} el
  */
 function getContentRect(el) {
 	let rect = getRect(el);


### PR DESCRIPTION
When an element that is a (light DOM) child of a shadow DOM element triggers an event (e.g., a click event), `getParentOrHost` checks for the parent shadow DOM's host (which refers to itself) causing [the do..while loop in `closest`](https://github.com/SortableJS/Sortable/blob/master/src/utils.js#L50-L65) to be called infinitely. 

This leads to the browser tab/window being frozen.

The solution is to check if the element passed to getParentOrHost has a host property that refers to itself.