### PR TITLE
fix: memory leak

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -2826,6 +2826,7 @@
       isMultiDrag: false,
       delayStartGlobal: function delayStartGlobal(_ref) {
         var dragged = _ref.dragEl;
+        if (!this.sortable.options.multiDrag) return;
         dragEl$1 = dragged;
       },
       delayEnded: function delayEnded() {

--- a/plugins/MultiDrag/MultiDrag.js
+++ b/plugins/MultiDrag/MultiDrag.js
@@ -71,6 +71,7 @@ function MultiDragPlugin() {
 
 
 		delayStartGlobal({ dragEl: dragged }) {
+			if (!this.sortable.options.multiDrag) return;
 			dragEl = dragged;
 		},
 


### PR DESCRIPTION
In a low-code–like platform, elements from the left panel are dragged onto the canvas on the right to generate a component, and the dragged source element is removed. When the newly generated component is deleted, a memory leak occurs.

The multiDrag property is not properly checked, causing the following code to execute even when multiDrag is set to false:
`delayStartGlobal({ dragEl: dragged }) {
    dragEl = dragged;
}`
<img width="2175" height="531" alt="1" src="https://github.com/user-attachments/assets/0649a8bc-5688-4082-be79-2141d6de06e2" />

When logging inside _onDrop, dragEl has already been removed from the DOM, but in MultiDrag.js, dragEl still retains a reference to the DOM node.
<img width="1398" height="75" alt="3" src="https://github.com/user-attachments/assets/5b3e6838-77e0-4fd8-832a-5e44bc3076f8" />
