### PR TITLE
Respect put: false on the revert-to-origin path

### DIFF
--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -1149,7 +1149,7 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 
 		if (activeSortable && !options.disabled &&
 			(isOwner
-				? canSort || (revert = parentEl !== rootEl) // Reverting item into the original list
+				? canSort || ((revert = parentEl !== rootEl) && group.checkPut(this, activeSortable, dragEl, evt)) // Reverting item into the original list
 				: (
 					putSortable === this ||
 					(


### PR DESCRIPTION
`group.put: false` is documented as preventing a sortable from receiving elements. It works correctly for cross-list drops from *other* sortables, but is silently ignored when a dragged item is reverted back to its *own* sortable.

This matters for clone-source lists (e.g. a sidebar with `pull: 'clone', put: false, sort: false`), items can be dragged out as clones, but nothing should be dropped back in. Currently, dragging an item out and then hovering back over the source triggers the revert branch, which bypasses `checkPut` entirely and reinserts `dragEl` into the source.

```
Sidebar                    Playlist

┌───────────┐              ┌───────────┐
│  Image    │              │  Scene 1  │
│  Video    │              │  Scene 2  │
│  Audio  │              │  Scene 3  │
└───────────┘              └───────────┘

1. Drag Image into Playlist (clone stays in Sidebar):

┌───────────┐              ┌───────────┐
│  Image    │              │  Scene 1  │
│  Video    │              │ [Image]   │
│  Audio  │              │  Scene 2  │
└───────────┘              │  Scene 3  │
                           └───────────┘

2. Hover cursor back over Sidebar:

┌───────────┐              ┌───────────┐
│ [Image]   │  <────────   │  Scene 1  │
│  Image    │   revert     │  Scene 2  │
│  Video    │   ignores    │  Scene 3  │
│  Audio  │   put:false  └───────────┘
└───────────┘
 ↑ dragEl forced back in,
   source now has both the
   clone AND the original
```

The [non-owner branch](https://github.com/SortableJS/Sortable/blob/48b626bbc61afbb0f179730c1dd3cca3dcc8b788/src/Sortable.js#L1153-L1158) of `_onDragOver` correctly gates on `group.checkPut`. The [owner branch](https://github.com/SortableJS/Sortable/blob/48b626bbc61afbb0f179730c1dd3cca3dcc8b788/src/Sortable.js#L1152) does not — it only checks `canSort`:

```js
(isOwner
    ? canSort || (revert = parentEl !== rootEl)
    : putSortable === this || (checkPull(...) && group.checkPut(...))
)
```

The asymmetry means `put: false` is enforced everywhere except the one code path where the source sortable acts as its own drop target.

Proposed fix:

Add `group.checkPut` to the owner branch so the revert condition mirrors the non-owner branch:

```js
? canSort || ((revert = parentEl !== rootEl) && group.checkPut(this, activeSortable, dragEl, evt))
```

This change only affects sortables that explicitly declare `put: false`. The default (`put: true` or unset) is unchanged because `checkPut` returns true.